### PR TITLE
chore(tests): normalize import order in test_cli per ruff 0.12

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,9 @@
 # License: MIT
 from pathlib import Path
 
-from ai_patch_verifier.cli import app
 from typer.testing import CliRunner
+
+from ai_patch_verifier.cli import app
 
 runner = CliRunner()
 


### PR DESCRIPTION
Adapta el orden de imports del test a ruff 0.12 para evitar diffs recurrentes y mantener CI estable. Sin cambios funcionales.