### PR TITLE
ci(dependabot): weekly updates for pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,17 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule: { interval: "weekly" }
-    open-pull-requests-limit: 2
-    labels: ["dependencies","ci"]
-    commit-message: { prefix: "deps" }
-
+  # Keep Python dependencies up to date
   - package-ecosystem: "pip"
     directory: "/"
-    schedule: { interval: "weekly" }
-    open-pull-requests-limit: 2
-    labels: ["dependencies","security"]
-    commit-message: { prefix: "deps" }
-    ignore:
-      - dependency-name: "click"
-      - dependency-name: "rich"
-      - dependency-name: "black"
-      - dependency-name: "typer"
-    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Enable Dependabot with weekly schedule for pip and GitHub Actions. PRs will be labeled as dependencies.